### PR TITLE
Change eslint to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,15 +64,14 @@
     "tslint": "4.5.1",
     "typescript": "2.2.1",
     "uglify-js": "2.8.5",
-    "watchify": "3.9.0"
+    "watchify": "3.9.0",
+    "eslint": "3.16.1",
+    "eslint-plugin-compat": "1.0.2"
   },
   "config": {
     "commitizen": {
       "path": "cz-conventional-changelog"
     }
   },
-  "dependencies": {
-    "eslint": "3.16.1",
-    "eslint-plugin-compat": "1.0.2"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
I have moved the `eslint`package to `devDepencies` to resolve my issue in nativescript-cli [#2651](https://github.com/NativeScript/nativescript-cli/issues/2561).